### PR TITLE
Fix blog search

### DIFF
--- a/search.json
+++ b/search.json
@@ -9,7 +9,6 @@ layout: null
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date | date: '%b %-d, %Y' }}",
-      //"content"  : "{{ post.content | strip_html | strip_newlines | escape }}",
       "article"  : "<div class='article col col-4 col-d-6 col-t-12 animate'> <div class='article__inner'> <div class='article__head'> <time class='article__date' datetime='{{post.date | date_to_xmlschema}}'>{{post.date | date_to_string}}</time>{% if post.video_embed %}<div class='video-icon'> <div class='circle pulse'></div><div class='circle'> <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'> <polygon points='40,30 65,50 40,70'></polygon> </svg> </div></div>{% endif %}{% if post.image %}<a class='article__image' href='{{post.url | prepend: site.baseurl}}'> <img src='{{site.baseurl}}{{post.image}}' alt='{{post.title | escape}}'> </a>{% endif %}</div><div class='article__content'> <h2 class='article__title'> <a href='{{post.url | prepend: site.baseurl}}'>{{post.title | escape}}</a> </h2>{% if post.description %}<p class='article__excerpt'>{{post.description | escape}}</p>{% endif %}</div></div></div>"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}


### PR DESCRIPTION
Remove comment in template code that is breaking the search functionality.

Removing the comment from the search.json file seems to fix the search.

Screen shot of the app working locally.

<img width="1203" alt="Screen Shot 2022-04-10 at 12 02 23 PM" src="https://user-images.githubusercontent.com/4009178/162635441-cbc7fdae-f2a9-4809-be17-e62424105c9a.png">

Tested on the Netlify deploy preview https://deploy-preview-22--amazing-borg-b90f51.netlify.app/ and it seems to also be working there.

One thing to note is it looks like the [Simple-Jekyll-Search](https://github.com/christian-fei/Simple-Jekyll-Search) doesn't seem to be being maintained. You may want to look into an alternative that has a more active community supporting the plugin.
