### PR TITLE
Implement preview card details

### DIFF
--- a/_includes/reading-time.html
+++ b/_includes/reading-time.html
@@ -1,0 +1,6 @@
+{% capture words %}
+{{ content | number_of_words | minus: 180 }}
+{% endcapture %}
+{% unless words contains '-' %}
+{{ words | plus: 150 | divided_by: 150 | append: ' minutes to read' }}
+{% endunless %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 <div class="post-head">
   <div class="container">
     <div class="row">
-      
+
       {% if page.video_embed %}
       <div class="col col-12">
         <div class="post-video">
@@ -25,11 +25,11 @@ layout: default
       {%endif %}
 
       {% endif %}
-      
+
       {% if page.video_embed %} {% assign videoInfo = 'post__info-video' %} {% endif %}
       <div class="col {% if page.video_embed %}col-12{% else %}col-6 col-d-12{% endif %}">
         <div class="post__info {{videoInfo}}">
-  
+
           {% if page.tags.size >= 1 %}
             <div class="post__tags">
               {% for tag in page.tags %}
@@ -37,9 +37,9 @@ layout: default
               {% endfor %}
             </div>
           {% endif %}
-  
+
           <h1 class="post__title">{{ page.title | escape }}</h1>
-  
+
           <div class="post__meta">
             <a href="{{site.baseurl}}/about/" class="post__author-image">
               <img class="lazy" data-src="{{site.author.author__avatar}}" alt="{{site.author.author__name}}">
@@ -48,9 +48,10 @@ layout: default
             <div class="post__meta-bottom">
               <a class="post__author" href="{{site.baseurl}}/about/">{{site.author.author__name}}</a>
               <time class="post__date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date_to_string }}</time>
+              <span class="post__reading-time">{% include reading-time.html %}</span>
             </div>
           </div>
-  
+
         </div>
       </div>
     </div>
@@ -97,7 +98,7 @@ layout: default
   <div class="container">
     <div class="row">
       <div class="col col-12">
-        {% include disqus-comments.html %} 
+        {% include disqus-comments.html %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Jekyll has documentation on a way to implement reading time without a plugin.

https://jekyllcodex.org/without-plugin/reading-time-indicator

I followed their instructions and added the reading time to the post templated. We can also add it to the search research / article previews.

We'll want to tighten up the design before releasing, but the functionality seems to work! 

Here is a screenshot of the info being rendered (unpolished) on the post page.

<img width="797" alt="Screen Shot 2022-04-10 at 12 42 59 PM" src="https://user-images.githubusercontent.com/4009178/162636866-91544401-51c6-46c7-b1c8-1575d6d17738.png">

Note my editor is set up to remove extra blank spaces, hence the extra lines removed. 